### PR TITLE
fix: fixed img bug, added placeholder image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ const Item = (props) => {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={props.item.image}
+                src={props.item.image === "" ? "../placeholder.png" : props.item.image}
                 alt={props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image === "" ? "../placeholder.png" : item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Previously we had broken images when displaying an image w/o an image URL provided by the user. 
Now, if the image URL is not provided, we default to a placeholder image.

<img width="738" alt="Screenshot 2023-04-06 at 16 14 57" src="https://user-images.githubusercontent.com/59029920/230404674-63b86353-24bd-44ae-9a52-23c2ad150618.png">
